### PR TITLE
finished add/remove association for create/edit posts

### DIFF
--- a/api/categoryPostData.js
+++ b/api/categoryPostData.js
@@ -16,6 +16,9 @@ const associateCategoryWithPost = async (postId, categoryId) => {
     }
 
     const data = await response.json();
+
+    console.log('Category associated with post successfully.');
+
     return data;
   } catch (error) {
     throw new Error(`Error associating category with post: ${error.message}`);
@@ -24,7 +27,7 @@ const associateCategoryWithPost = async (postId, categoryId) => {
 
 const dissociateCategoryFromPost = async (postId, categoryId) => {
   try {
-    const response = await fetch(`${dbUrl}/api/posts/${postId}/categories/${categoryId}`, {
+    const response = await fetch(`${dbUrl}/api/CategoryPost?postId=${postId}&categoryId=${categoryId}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
@@ -36,13 +39,29 @@ const dissociateCategoryFromPost = async (postId, categoryId) => {
     }
 
     const data = await response.json();
+
+    console.log('Category dissociated from post successfully.');
+
     return data;
   } catch (error) {
     throw new Error(`Error dissociating category from post: ${error.message}`);
   }
 };
 
+async function fetchAssociatedCategoriesForPost(postId) {
+  try {
+    const response = await fetch(`${dbUrl}/api/posts/${postId}/categories`);
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    return response.json();
+  } catch (error) {
+    throw new Error(`Error fetching associated categories: ${error.message}`);
+  }
+}
+
 export {
   associateCategoryWithPost,
   dissociateCategoryFromPost,
+  fetchAssociatedCategoriesForPost,
 };

--- a/components/PostCard.js
+++ b/components/PostCard.js
@@ -45,5 +45,9 @@ PostCard.propTypes = {
     description: PropTypes.string,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
-  userIdent: PropTypes.number.isRequired,
+  userIdent: PropTypes.number,
+};
+
+PostCard.defaultProps = {
+  userIdent: undefined,
 };

--- a/pages/posts/edit/[id].js
+++ b/pages/posts/edit/[id].js
@@ -9,10 +9,17 @@ export default function EditPost() {
   const { id } = router.query;
 
   useEffect(() => {
-    getSinglePost(id).then(setPost);
+    console.log('ID Changed:', id);
+    getSinglePost(id)
+      .then((post) => {
+        console.log('Fetched Post:', post);
+        setPost(post);
+      })
+      .catch((error) => {
+        console.error('Error fetching post:', error);
+      });
   }, [id]);
 
-  return (
-    <PostForm obj={editPost} />
-  );
+  // Use conditional rendering to ensure that PostForm is only rendered when editPost has data
+  return editPost.id ? <PostForm obj={editPost} /> : null;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
added necessary for for add/remove association on create/edit posts,
also changed userIdent to not be required on postForm and postCard to avoid the console errors. 
To my knowledge, we are still able to access the userIdent data where needed. 


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#10 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
users could not remove or edit category association before, this new code solves that. 


## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->
create a new post with categories associated. Then edit the post, and uncheck one or more categories, this should update the join table immediately when unchecking or checking a box.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
